### PR TITLE
 fix: poi grid alignment in OnGridSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ GameBinaries
 TorchBinaries
 *.sbcB5
 *.blend1
+**/.vs/

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Merchants/PoiMerchant.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Merchants/PoiMerchant.cs
@@ -216,9 +216,10 @@ namespace HnzCoopSeason.Merchants
                 newMat.Forward = gridForward;
                 newMat.Right = gridRight;
                 newMat.Up = gridUp;
+
                 var planet = MyGamePruningStructure.GetClosestPlanet(pos);
                 var surfPts = planet.GetClosestSurfacePointGlobal(pos);
-                newMat.Translation += surfPts - pos; // Move up to surfPts
+                newMat.Translation = surfPts;
 
                 _grid.SetWorldMatrix(newMat);
             }


### PR DESCRIPTION
Transform grid after spawned.
- Align grid rotation matrix with planet gravity.
- Translate grid origin up to the planet surface.