### PR TITLE
feat: per-level ork hp multipliers, invasion improvement & spawn_noai

### DIFF
--- a/HnzCoopSeason.Mod/Content/Data/ModStorageComponents.sbc
+++ b/HnzCoopSeason.Mod/Content/Data/ModStorageComponents.sbc
@@ -8,6 +8,7 @@
             </Id>
             <RegisteredStorageGuids>
                 <guid>8e562067-5807-49a0-9d7d-108febcece97</guid>
+                <guid>f2f7a2a0-4f60-4f4e-9f0e-6f4b1a2e9c11</guid>
             </RegisteredStorageGuids>
         </EntityComponent>
     </EntityComponents>

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkDamageReductionScales.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkDamageReductionScales.cs
@@ -8,44 +8,44 @@ using VRage.Utils;
 
 namespace HnzCoopSeason.Orks
 {
-    // hp multiplier per ork grid, frozen at spawn time from the encounter's progress level.
+    // damage reduction scale per ork grid, frozen at spawn time from the encounter's progress level.
     // values only; no entity references held, so a missed removal can't pin a grid.
     // persisted into the grid's mod storage so the value survives a world restart.
-    public static class OrkHpMultipliers
+    public static class OrkDamageReductionScales
     {
         static readonly Guid ModStorageKey = new Guid("f2f7a2a0-4f60-4f4e-9f0e-6f4b1a2e9c11");
 
-        static readonly Dictionary<long, float> Multipliers = new Dictionary<long, float>();
+        static readonly Dictionary<long, float> Scales = new Dictionary<long, float>();
 
-        public static void Register(IMyCubeGrid grid, float multiplier)
+        public static void Register(IMyCubeGrid grid, float scale)
         {
             if (grid == null || grid.Closed || grid.MarkedForClose) return;
 
-            Multipliers[grid.EntityId] = multiplier;
-            grid.UpdateStorageValue(ModStorageKey, multiplier.ToString(CultureInfo.InvariantCulture));
+            Scales[grid.EntityId] = scale;
+            grid.UpdateStorageValue(ModStorageKey, scale.ToString(CultureInfo.InvariantCulture));
 
             grid.OnClosing -= OnGridClosing; // no double-subscribe on re-register
             grid.OnClosing += OnGridClosing;
 
-            MyLog.Default.Info($"[HnzCoopSeason] ork hp multiplier registered: '{grid.CustomName}' x{multiplier:0.##}");
+            MyLog.Default.Info($"[HnzCoopSeason] ork damage reduction scale registered: '{grid.CustomName}' x{scale:0.##}");
         }
 
-        public static bool TryGet(IMyCubeGrid grid, out float multiplier)
+        public static bool TryGet(IMyCubeGrid grid, out float scale)
         {
-            if (Multipliers.TryGetValue(grid.EntityId, out multiplier)) return true;
+            if (Scales.TryGetValue(grid.EntityId, out scale)) return true;
 
             // grid from before a restart: recover from its mod storage, then cache
             string str;
             if (!grid.TryGetStorageValue(ModStorageKey, out str)) return false;
-            if (!float.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out multiplier)) return false;
+            if (!float.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out scale)) return false;
 
-            Multipliers[grid.EntityId] = multiplier;
+            Scales[grid.EntityId] = scale;
             grid.OnClosing -= OnGridClosing;
             grid.OnClosing += OnGridClosing;
             return true;
         }
 
-        // a stored multiplier doubles as the "this grid was ork-spawned" marker
+        // a stored scale doubles as the "this grid was ork-spawned" marker
         public static bool HasStored(IMyEntity entity)
         {
             string str;
@@ -54,13 +54,13 @@ namespace HnzCoopSeason.Orks
 
         public static void Clear() // session unload
         {
-            Multipliers.Clear();
+            Scales.Clear();
         }
 
         static void OnGridClosing(IMyEntity entity)
         {
             entity.OnClosing -= OnGridClosing;
-            Multipliers.Remove(entity.EntityId);
+            Scales.Remove(entity.EntityId);
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkHpMultipliers.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkHpMultipliers.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using VRage.Game.ModAPI;
+using VRage.ModAPI;
+using VRage.Utils;
+
+namespace HnzCoopSeason.Orks
+{
+    // hp multiplier per ork grid, frozen at spawn time from the encounter's progress level.
+    // values only; no entity references held, so a missed removal can't pin a grid.
+    public static class OrkHpMultipliers
+    {
+        static readonly Dictionary<long, float> Multipliers = new Dictionary<long, float>();
+
+        public static void Register(IMyCubeGrid grid, float multiplier)
+        {
+            if (grid == null || grid.Closed || grid.MarkedForClose) return;
+
+            Multipliers[grid.EntityId] = multiplier;
+
+            grid.OnClosing -= OnGridClosing; // no double-subscribe on re-register
+            grid.OnClosing += OnGridClosing;
+
+            MyLog.Default.Info($"[HnzCoopSeason] ork hp multiplier registered: '{grid.CustomName}' x{multiplier:0.##}");
+        }
+
+        public static bool TryGet(IMyCubeGrid grid, out float multiplier)
+        {
+            return Multipliers.TryGetValue(grid.EntityId, out multiplier);
+        }
+
+        public static void Clear() // session unload
+        {
+            Multipliers.Clear();
+        }
+
+        static void OnGridClosing(IMyEntity entity)
+        {
+            entity.OnClosing -= OnGridClosing;
+            Multipliers.Remove(entity.EntityId);
+        }
+    }
+}

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkHpMultipliers.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkHpMultipliers.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using HnzUtils;
 using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using VRage.Utils;
@@ -7,8 +10,11 @@ namespace HnzCoopSeason.Orks
 {
     // hp multiplier per ork grid, frozen at spawn time from the encounter's progress level.
     // values only; no entity references held, so a missed removal can't pin a grid.
+    // persisted into the grid's mod storage so the value survives a world restart.
     public static class OrkHpMultipliers
     {
+        static readonly Guid ModStorageKey = new Guid("f2f7a2a0-4f60-4f4e-9f0e-6f4b1a2e9c11");
+
         static readonly Dictionary<long, float> Multipliers = new Dictionary<long, float>();
 
         public static void Register(IMyCubeGrid grid, float multiplier)
@@ -16,6 +22,7 @@ namespace HnzCoopSeason.Orks
             if (grid == null || grid.Closed || grid.MarkedForClose) return;
 
             Multipliers[grid.EntityId] = multiplier;
+            grid.UpdateStorageValue(ModStorageKey, multiplier.ToString(CultureInfo.InvariantCulture));
 
             grid.OnClosing -= OnGridClosing; // no double-subscribe on re-register
             grid.OnClosing += OnGridClosing;
@@ -25,7 +32,24 @@ namespace HnzCoopSeason.Orks
 
         public static bool TryGet(IMyCubeGrid grid, out float multiplier)
         {
-            return Multipliers.TryGetValue(grid.EntityId, out multiplier);
+            if (Multipliers.TryGetValue(grid.EntityId, out multiplier)) return true;
+
+            // grid from before a restart: recover from its mod storage, then cache
+            string str;
+            if (!grid.TryGetStorageValue(ModStorageKey, out str)) return false;
+            if (!float.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out multiplier)) return false;
+
+            Multipliers[grid.EntityId] = multiplier;
+            grid.OnClosing -= OnGridClosing;
+            grid.OnClosing += OnGridClosing;
+            return true;
+        }
+
+        // a stored multiplier doubles as the "this grid was ork-spawned" marker
+        public static bool HasStored(IMyEntity entity)
+        {
+            string str;
+            return entity.TryGetStorageValue(ModStorageKey, out str);
         }
 
         public static void Clear() // session unload

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkUtils.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkUtils.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using Sandbox.ModAPI;
+using SpaceEngineers.Game.ModAPI;
+using VRage.Game.ModAPI;
+
+namespace HnzCoopSeason.Orks
+{
+    public static class OrkUtils
+    {
+
+        public static int DisarmGrid(IMyCubeGrid grid)
+        {
+            var count = 0;
+
+            // rival ai brain: the MES behavior lives on the remote control and keeps flying/taunting even with
+            // autopilot off (and MyRemoteControl is NOT an IMyFunctionalBlock -- a direct cast crashes the game).
+            // Removing the block kills the behavior outright; dampeners then brake the grid to a stop.
+            var remotes = new List<IMyRemoteControl>();
+            foreach (var block in grid.GetFatBlocks<IMyRemoteControl>())
+            {
+                remotes.Add(block);
+            }
+
+            foreach (var block in remotes)
+            {
+                block.SetAutoPilotEnabled(false);
+                grid.RemoveBlock(block.SlimBlock, true);
+                count += 1;
+            }
+
+            foreach (var block in grid.GetFatBlocks<IMyUserControllableGun>())
+            {
+                block.Enabled = false;
+                count += 1;
+            }
+
+            foreach (var block in grid.GetFatBlocks<IMyConveyorSorter>())
+            {
+                block.Enabled = false; // weaponcore sorter-weapons
+                count += 1;
+            }
+
+            // static weapons fired by controllers rather than their own AI
+            foreach (var block in grid.GetFatBlocks<IMyTurretControlBlock>())
+            {
+                block.Enabled = false;
+                count += 1;
+            }
+
+            foreach (var block in grid.GetFatBlocks<IMyOffensiveCombatBlock>())
+            {
+                block.Enabled = false; // automatons combat ai
+                count += 1;
+            }
+
+            foreach (var block in grid.GetFatBlocks<IMyDefensiveCombatBlock>())
+            {
+                block.Enabled = false;
+                count += 1;
+            }
+
+            foreach (var block in grid.GetFatBlocks<IMyFlightMovementBlock>())
+            {
+                block.Enabled = false;
+                count += 1;
+            }
+
+            foreach (var block in grid.GetFatBlocks<IMyWarhead>())
+            {
+                block.IsArmed = false;
+                count += 1;
+            }
+
+            return count;
+        }
+    }
+}

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkUtils.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkUtils.cs
@@ -8,12 +8,12 @@ namespace HnzCoopSeason.Orks
 {
     public static class OrkUtils
     {
-        // hp multiplier a grid of the given progress level should carry, at this point of the season
-        public static float ComputeHpMultiplier(int level)
+        // damage reduction scale a grid of the given progress level should carry, at this point of the season
+        public static float ComputeOrksDamageReductionScale(int level)
         {
             var c = SessionConfig.Instance.GetProgressionLevel(level);
             var t = Session.Instance.GetProgressLevelFraction(level);
-            return MathHelper.Lerp(c.HpMultiplierStart, c.HpMultiplierEnd, t);
+            return MathHelper.Lerp(c.OrksDamageReductionScaleStart, c.OrksDamageReductionScaleEnd, t);
         }
 
         public static int DisarmGrid(IMyCubeGrid grid)

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkUtils.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrkUtils.cs
@@ -2,11 +2,19 @@ using System.Collections.Generic;
 using Sandbox.ModAPI;
 using SpaceEngineers.Game.ModAPI;
 using VRage.Game.ModAPI;
+using VRageMath;
 
 namespace HnzCoopSeason.Orks
 {
     public static class OrkUtils
     {
+        // hp multiplier a grid of the given progress level should carry, at this point of the season
+        public static float ComputeHpMultiplier(int level)
+        {
+            var c = SessionConfig.Instance.GetProgressionLevel(level);
+            var t = Session.Instance.GetProgressLevelFraction(level);
+            return MathHelper.Lerp(c.HpMultiplierStart, c.HpMultiplierEnd, t);
+        }
 
         public static int DisarmGrid(IMyCubeGrid grid)
         {

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrksDamageManipulator.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrksDamageManipulator.cs
@@ -48,7 +48,14 @@ namespace HnzCoopSeason.Orks
             if (!block.CubeGrid.BigOwners.TryGetElementAt(0, out ownerId)) return;
             if (ownerId != _factionFounderId) return;
 
-            info.Amount *= 1f / Math.Max(_multiplier, 1f);
+            // per-grid multiplier frozen at spawn time; grids from before a restart fall back to the session level
+            float multiplier;
+            if (!OrkHpMultipliers.TryGet(block.CubeGrid, out multiplier))
+            {
+                multiplier = _multiplier;
+            }
+
+            info.Amount *= 1f / Math.Max(multiplier, 1f);
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrksDamageManipulator.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrksDamageManipulator.cs
@@ -3,6 +3,7 @@ using HnzUtils;
 using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
 using VRage.Utils;
+using VRageMath;
 
 namespace HnzCoopSeason.Orks
 {
@@ -10,8 +11,7 @@ namespace HnzCoopSeason.Orks
     {
         readonly string _factionTag;
         long _factionFounderId;
-        int _level;
-
+        float _multiplier = 1f;
 
         public OrksDamageManipulator(string factionTag)
         {
@@ -34,7 +34,9 @@ namespace HnzCoopSeason.Orks
 
         public void OnEveryFrame()
         {
-            _level = Session.Instance.GetProgressLevel();
+            var level = Session.Instance.GetProgressLevel();
+            var c = SessionConfig.Instance.GetProgressionLevel(level);
+            _multiplier = MathHelper.Lerp(c.HpMultiplierStart, c.HpMultiplierEnd, Session.Instance.GetProgressLevelFraction());
         }
 
         void BeforeDamage(object target, ref MyDamageInformation info)
@@ -46,8 +48,7 @@ namespace HnzCoopSeason.Orks
             if (!block.CubeGrid.BigOwners.TryGetElementAt(0, out ownerId)) return;
             if (ownerId != _factionFounderId) return;
 
-            var magnitude = _level * SessionConfig.Instance.OrksDamageManipulationScale;
-            info.Amount *= 1f / Math.Max(magnitude, 1f);
+            info.Amount *= 1f / Math.Max(_multiplier, 1f);
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrksDamageManipulator.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/OrksDamageManipulator.cs
@@ -11,7 +11,7 @@ namespace HnzCoopSeason.Orks
     {
         readonly string _factionTag;
         long _factionFounderId;
-        float _multiplier = 1f;
+        float _scale = 1f;
 
         public OrksDamageManipulator(string factionTag)
         {
@@ -36,7 +36,7 @@ namespace HnzCoopSeason.Orks
         {
             var level = Session.Instance.GetProgressLevel();
             var c = SessionConfig.Instance.GetProgressionLevel(level);
-            _multiplier = MathHelper.Lerp(c.HpMultiplierStart, c.HpMultiplierEnd, Session.Instance.GetProgressLevelFraction());
+            _scale = MathHelper.Lerp(c.OrksDamageReductionScaleStart, c.OrksDamageReductionScaleEnd, Session.Instance.GetProgressLevelFraction());
         }
 
         void BeforeDamage(object target, ref MyDamageInformation info)
@@ -48,14 +48,14 @@ namespace HnzCoopSeason.Orks
             if (!block.CubeGrid.BigOwners.TryGetElementAt(0, out ownerId)) return;
             if (ownerId != _factionFounderId) return;
 
-            // per-grid multiplier frozen at spawn time; grids from before a restart fall back to the session level
-            float multiplier;
-            if (!OrkHpMultipliers.TryGet(block.CubeGrid, out multiplier))
+            // per-grid scale frozen at spawn time; grids from before a restart fall back to the session level
+            float scale;
+            if (!OrkDamageReductionScales.TryGet(block.CubeGrid, out scale))
             {
-                multiplier = _multiplier;
+                scale = _scale;
             }
 
-            info.Amount *= 1f / Math.Max(multiplier, 1f);
+            info.Amount *= 1f / Math.Max(scale, 1f);
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiOrk.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiOrk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FlashGps;
@@ -20,6 +20,7 @@ namespace HnzCoopSeason.Orks
         readonly PoiOrkConfig[] _configs;
         IMyCubeGrid _mainGrid;
         PoiState _poiState;
+        bool _disarmNextSpawn;
 
         public PoiOrk(string poiId, Vector3D position, PoiOrkConfig[] configs)
         {
@@ -32,6 +33,7 @@ namespace HnzCoopSeason.Orks
         {
             _encounter.OnMainGridSet += OnMainGridSet;
             _encounter.OnMainGridUnset += OnMainGridUnset;
+            _encounter.OnGridSet += OnGridSet;
             _encounter.FilterSpawn = EncounterSpawnDelegate;
             _encounter.Load(grids);
 
@@ -43,6 +45,7 @@ namespace HnzCoopSeason.Orks
             _encounter.Unload(sessionUnload);
             _encounter.OnMainGridSet -= OnMainGridSet;
             _encounter.OnMainGridUnset -= OnMainGridUnset;
+            _encounter.OnGridSet -= OnGridSet;
             _encounter.FilterSpawn = null;
 
             CoopGridTakeover.Instance.OnTakeoverStateChanged -= OnAnyTakeoverStateChanged;
@@ -138,6 +141,8 @@ namespace HnzCoopSeason.Orks
         // called upon encounter spawn
         bool EncounterSpawnDelegate(int playerCount, List<string> spawnGroupNames)
         {
+            _disarmNextSpawn = false; // natural spawns are always armed
+
             var minPlayerCount = GetMinPlayerCount();
             if (playerCount < minPlayerCount) return false;
 
@@ -157,10 +162,20 @@ namespace HnzCoopSeason.Orks
             return SessionConfig.Instance.ProgressionLevels[progressLevel].MinPlayerCount;
         }
 
-        public void Spawn(int configIndex)
+        public void Spawn(int configIndex, bool disarm = false)
         {
+            _disarmNextSpawn = disarm;
+
             var config = _configs[configIndex];
             _encounter.ForceSpawn(config.SpawnGroupNames);
+        }
+
+        void OnGridSet(IMyCubeGrid grid)
+        {
+            if (!_disarmNextSpawn) return;
+
+            var count = OrkUtils.DisarmGrid(grid);
+            MyLog.Default.Info($"[HnzCoopSeason] ork {_poiId} grid disarmed: '{grid.CustomName}', blocks: {count}");
         }
 
         int CalcConfigIndex()

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiOrk.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiOrk.cs
@@ -172,7 +172,7 @@ namespace HnzCoopSeason.Orks
 
         void OnGridSet(IMyCubeGrid grid)
         {
-            OrkHpMultipliers.Register(grid, OrkUtils.ComputeHpMultiplier(GetProgressLevel()));
+            OrkDamageReductionScales.Register(grid, OrkUtils.ComputeOrksDamageReductionScale(GetProgressLevel()));
 
             if (!_disarmNextSpawn) return;
 

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiOrk.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiOrk.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using FlashGps;
@@ -172,6 +172,8 @@ namespace HnzCoopSeason.Orks
 
         void OnGridSet(IMyCubeGrid grid)
         {
+            OrkHpMultipliers.Register(grid, OrkUtils.ComputeHpMultiplier(GetProgressLevel()));
+
             if (!_disarmNextSpawn) return;
 
             var count = OrkUtils.DisarmGrid(grid);

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiRandomInvasion.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiRandomInvasion.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+using System;
+using System.Linq;
 using HnzCoopSeason.POI;
 using Sandbox.ModAPI;
 using VRage.Library.Utils;
@@ -10,8 +11,25 @@ namespace HnzCoopSeason.Orks
     {
         public static readonly PoiRandomInvasion Instance = new PoiRandomInvasion();
 
+        // GameDateTime is backed by the checkpoint's ElapsedGameTime.
+        const string VariableKey = "HnzCoopSeason.PoiRandomInvasion.LastWindowGameTicks";
+        long _lastWindowTicks;
+
         public void Load()
         {
+            long ticks;
+            if (MyAPIGateway.Utilities.GetVariable(VariableKey, out ticks))
+            {
+                _lastWindowTicks = ticks;
+                MyLog.Default.Info($"[HnzCoopSeason] invasion timer restored; last window ticks: {_lastWindowTicks}");
+            }
+            else
+            {
+                // fresh world: wait one full interval before the first invasion
+                _lastWindowTicks = MyAPIGateway.Session.GameDateTime.Ticks;
+                Save();
+                MyLog.Default.Info("[HnzCoopSeason] invasion timer initialized");
+            }
         }
 
         public void Unload()
@@ -20,8 +38,15 @@ namespace HnzCoopSeason.Orks
 
         public void Update()
         {
-            var interval = SessionConfig.Instance.InvasionIntervalHours * 60 * 60 * 60;
-            if (MyAPIGateway.Session.GameplayFrameCounter % interval != 0) return;
+            // throttle the poi scan to once/sec; the actual cadence uses persisted game-time below
+            if (MyAPIGateway.Session.GameplayFrameCounter % 60 != 0) return;
+
+            var intervalTicks = TimeSpan.FromHours(SessionConfig.Instance.InvasionIntervalHours).Ticks;
+            var nowTicks = MyAPIGateway.Session.GameDateTime.Ticks;
+            if (nowTicks - _lastWindowTicks < intervalTicks) return;
+
+            _lastWindowTicks = nowTicks;
+            Save();
 
             if (Session.Instance.GetProgress() >= 1f)
             {
@@ -49,6 +74,11 @@ namespace HnzCoopSeason.Orks
             {
                 MyLog.Default.Warning($"[HnzCoopSeason] failed to initiate invasion: {poi.Id}");
             }
+        }
+
+        void Save()
+        {
+            MyAPIGateway.Utilities.SetVariable(VariableKey, _lastWindowTicks);
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiRandomInvasion.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiRandomInvasion.cs
@@ -64,6 +64,7 @@ namespace HnzCoopSeason.Orks
             var poi = Session.Instance.GetAllPois()
                 .Where(p => p.State == PoiState.Released)
                 .Where(p => !p.IsPlanetary) // can't have planetary poi invaded; "pending" kicks in
+                .Where(p => nowTicks - p.ReleasedAtGameTicks >= intervalTicks) // grace: don't re-invade a recently-liberated poi
                 .OrderBy(_ => MyRandom.Instance.NextDouble()) // random order
                 .FirstOrDefault();
 

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiRandomInvasion.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/PoiRandomInvasion.cs
@@ -23,9 +23,16 @@ namespace HnzCoopSeason.Orks
             var interval = SessionConfig.Instance.InvasionIntervalHours * 60 * 60 * 60;
             if (MyAPIGateway.Session.GameplayFrameCounter % interval != 0) return;
 
-            if (Session.Instance.GetAllPois().Any(p => p.State == PoiState.Invaded))
+            if (Session.Instance.GetProgress() >= 1f)
             {
-                MyLog.Default.Info("[HnzCoopSeason] aborting invasion; already got one");
+                MyLog.Default.Info("[HnzCoopSeason] aborting invasion; peace restored");
+                return;
+            }
+
+            var invadedCount = Session.Instance.GetAllPois().Count(p => p.State == PoiState.Invaded);
+            if (invadedCount >= SessionConfig.Instance.MaxConcurrentInvasions)
+            {
+                MyLog.Default.Info($"[HnzCoopSeason] aborting invasion; max concurrent reached: {invadedCount}");
                 return;
             }
 

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
@@ -59,7 +59,7 @@ namespace HnzCoopSeason.Orks
                 foreach (var entity in entities)
                 {
                     if (entity.MarkedForClose) continue;
-                    if (!OrkHpMultipliers.HasStored(entity)) continue;
+                    if (!OrkDamageReductionScales.HasStored(entity)) continue;
 
                     MyLog.Default.Info($"[HnzCoopSeason] revenge despawn: closing restored ork grid '{((IMyCubeGrid)entity).CustomName}'");
                     entity.Close();
@@ -103,7 +103,7 @@ namespace HnzCoopSeason.Orks
 
         void OnGridSet(IMyCubeGrid grid)
         {
-            OrkHpMultipliers.Register(grid, OrkUtils.ComputeHpMultiplier(_spawnLevel));
+            OrkDamageReductionScales.Register(grid, OrkUtils.ComputeOrksDamageReductionScale(_spawnLevel));
         }
 
         void SpawnNoAi(Vector3D center, string[] spawnGroupNames)

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
@@ -1,7 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using HnzCoopSeason.Spawners;
+using Sandbox.Definitions;
+using Sandbox.ModAPI;
+using VRage.Game;
 using VRage.Game.ModAPI;
+using VRage.Utils;
 using VRageMath;
 
 namespace HnzCoopSeason.Orks
@@ -10,12 +14,25 @@ namespace HnzCoopSeason.Orks
     {
         public static readonly RevengeOrkManager Instance = new RevengeOrkManager();
 
+        const string OrkFactionTag = "PORKS";
+
+        const double NoAiSpawnMargin = 50;
+
         LinkedList<MesEncounter> _orks;
+        List<IMyCubeGrid> _noAiGrids;
         int _increment;
+
+        // sequential no-ai spawn state: one prefab per tick, each placed past the previous ship's measured bounds
+        Queue<string> _noAiQueue;
+        Vector3D _noAiOrigin;
+        Vector3D _noAiAxis;
+        double _noAiEdge;
+        long _noAiOwnerId;
 
         public void Load()
         {
             _orks = new LinkedList<MesEncounter>();
+            _noAiGrids = new List<IMyCubeGrid>();
         }
 
         void Clear(bool sessionUnload)
@@ -26,6 +43,17 @@ namespace HnzCoopSeason.Orks
             }
 
             _orks.Clear();
+
+            if (!sessionUnload)
+            {
+                foreach (var grid in _noAiGrids)
+                {
+                    if (grid != null && !grid.MarkedForClose) grid.Close();
+                }
+            }
+
+            _noAiGrids.Clear();
+            _noAiQueue = null; // abort any in-flight sequential spawn
         }
 
         public void Unload()
@@ -33,8 +61,21 @@ namespace HnzCoopSeason.Orks
             Clear(true);
         }
 
-        public void Spawn(Vector3 position, string[] spawnGroupNames)
+        public void DespawnAll()
         {
+            Clear(false);
+        }
+
+        public void Spawn(Vector3 position, string[] spawnGroupNames, bool disarm = false)
+        {
+            if (disarm)
+            {
+                // no-ai spawn: no MES involved at all -- direct prefab spawn owned by the ork faction,
+                // so the grids sit in the hp-multiplier damage watcher without any behavior flying/taunting.
+                SpawnNoAi(position, spawnGroupNames);
+                return;
+            }
+
             var ork = new MesEncounter($"revenge-ork-{_increment++}", position);
             _orks.AddLast(ork);
 
@@ -42,9 +83,92 @@ namespace HnzCoopSeason.Orks
             ork.ForceSpawn(spawnGroupNames);
         }
 
-        public void DespawnAll()
+        void SpawnNoAi(Vector3D center, string[] spawnGroupNames)
         {
-            Clear(false);
+            var faction = MyAPIGateway.Session.Factions.TryGetFactionByTag(OrkFactionTag);
+            if (faction == null)
+            {
+                MyLog.Default.Error($"[HnzCoopSeason] revenge no-ai spawn: faction not found: '{OrkFactionTag}'");
+                return;
+            }
+
+            _noAiQueue = new Queue<string>();
+            foreach (var groupName in spawnGroupNames)
+            {
+                MySpawnGroupDefinition group = null;
+                foreach (var d in MyDefinitionManager.Static.GetSpawnGroupDefinitions())
+                {
+                    if (d.Id.SubtypeName == groupName)
+                    {
+                        group = d;
+                        break;
+                    }
+                }
+
+                if (group == null)
+                {
+                    MyLog.Default.Warning($"[HnzCoopSeason] revenge no-ai spawn: spawn group not found: '{groupName}'");
+                    continue;
+                }
+
+                foreach (var prefab in group.Prefabs)
+                {
+                    _noAiQueue.Enqueue(prefab.SubtypeId);
+                }
+            }
+
+            _noAiOwnerId = faction.FounderId;
+            _noAiOrigin = center;
+            _noAiAxis = Vector3D.Right;
+            _noAiEdge = 0;
+            SpawnNextNoAi();
+        }
+
+        void SpawnNextNoAi()
+        {
+            if (_noAiQueue == null || _noAiQueue.Count == 0) return;
+
+            var prefabName = _noAiQueue.Dequeue();
+            var def = MyDefinitionManager.Static.GetPrefabDefinition(prefabName);
+            double radius = def != null && def.BoundingSphere.Radius > 0 ? def.BoundingSphere.Radius : 100;
+
+            // place this ship's center one bounding-radius past the current free edge
+            var position = _noAiOrigin + _noAiAxis * (_noAiEdge + NoAiSpawnMargin + radius);
+            var fallbackEdge = _noAiEdge + NoAiSpawnMargin + radius * 2;
+            var grids = new List<IMyCubeGrid>();
+            MyAPIGateway.PrefabManager.SpawnPrefab(
+                grids, prefabName, position, Vector3.Forward, Vector3.Up,
+                Vector3.Zero, Vector3.Zero, null, SpawningOptions.None, _noAiOwnerId, false, () =>
+                {
+                    // measure what actually spawned and advance the free edge past its bounds
+                    var edge = fallbackEdge;
+                    foreach (var grid in grids)
+                    {
+                        _noAiGrids.Add(grid);
+                        var count = OrkUtils.DisarmGrid(grid);
+                        MyLog.Default.Info($"[HnzCoopSeason] no-ai ork spawned: '{grid.CustomName}', disarmed blocks: {count}");
+
+                        var corners = grid.WorldAABB.GetCorners();
+                        foreach (var corner in corners)
+                        {
+                            edge = Math.Max(edge, Vector3D.Dot(corner - _noAiOrigin, _noAiAxis));
+                        }
+                    }
+
+                    _noAiEdge = edge;
+                    DeferTicks(10, SpawnNextNoAi);
+                });
+        }
+
+        static void DeferTicks(int ticks, Action action)
+        {
+            if (ticks <= 0)
+            {
+                action();
+                return;
+            }
+
+            MyAPIGateway.Utilities.InvokeOnGameThread(() => DeferTicks(ticks - 1, action));
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
@@ -172,10 +172,10 @@ namespace HnzCoopSeason.Orks
                         var count = OrkUtils.DisarmGrid(grid);
                         MyLog.Default.Info($"[HnzCoopSeason] no-ai ork spawned: '{grid.CustomName}', disarmed blocks: {count}");
 
-                        var corners = grid.WorldAABB.GetCorners();
-                        foreach (var corner in corners)
+                        var aabb = grid.WorldAABB;
+                        for (var i = 0; i < 8; i++)
                         {
-                            edge = Math.Max(edge, Vector3D.Dot(corner - _noAiOrigin, _noAiAxis));
+                            edge = Math.Max(edge, Vector3D.Dot(aabb.GetCorner(i) - _noAiOrigin, _noAiAxis));
                         }
                     }
 

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
@@ -5,6 +5,7 @@ using Sandbox.Definitions;
 using Sandbox.ModAPI;
 using VRage.Game;
 using VRage.Game.ModAPI;
+using VRage.ModAPI;
 using VRage.Utils;
 using VRageMath;
 
@@ -28,6 +29,7 @@ namespace HnzCoopSeason.Orks
         Vector3D _noAiAxis;
         double _noAiEdge;
         long _noAiOwnerId;
+        int _spawnLevel = 1;
 
         public void Load()
         {
@@ -50,6 +52,18 @@ namespace HnzCoopSeason.Orks
                 {
                     if (grid != null && !grid.MarkedForClose) grid.Close();
                 }
+
+                // grids from before a restart aren't in the list; a stored hp multiplier marks them ork-spawned
+                var entities = new HashSet<IMyEntity>();
+                MyAPIGateway.Entities.GetEntities(entities, e => e is IMyCubeGrid);
+                foreach (var entity in entities)
+                {
+                    if (entity.MarkedForClose) continue;
+                    if (!OrkHpMultipliers.HasStored(entity)) continue;
+
+                    MyLog.Default.Info($"[HnzCoopSeason] revenge despawn: closing restored ork grid '{((IMyCubeGrid)entity).CustomName}'");
+                    entity.Close();
+                }
             }
 
             _noAiGrids.Clear();
@@ -66,8 +80,11 @@ namespace HnzCoopSeason.Orks
             Clear(false);
         }
 
-        public void Spawn(Vector3 position, string[] spawnGroupNames, bool disarm = false)
+        public void Spawn(Vector3 position, string[] spawnGroupNames, int level, bool disarm = false)
         {
+            // revenge orks have no poi; they fight at the level of the ork config they spawned from
+            _spawnLevel = level;
+
             if (disarm)
             {
                 // no-ai spawn: no MES involved at all -- direct prefab spawn owned by the ork faction,
@@ -84,11 +101,9 @@ namespace HnzCoopSeason.Orks
             ork.ForceSpawn(spawnGroupNames);
         }
 
-        static void OnGridSet(IMyCubeGrid grid)
+        void OnGridSet(IMyCubeGrid grid)
         {
-            // revenge orks have no poi; they fight at the session's current level
-            var level = Session.Instance.GetProgressLevel();
-            OrkHpMultipliers.Register(grid, OrkUtils.ComputeHpMultiplier(level));
+            OrkHpMultipliers.Register(grid, OrkUtils.ComputeHpMultiplier(_spawnLevel));
         }
 
         void SpawnNoAi(Vector3D center, string[] spawnGroupNames)

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Orks/RevengeOrkManager.cs
@@ -79,8 +79,16 @@ namespace HnzCoopSeason.Orks
             var ork = new MesEncounter($"revenge-ork-{_increment++}", position);
             _orks.AddLast(ork);
 
+            ork.OnGridSet += OnGridSet; // cleared by the encounter's own Unload
             ork.Load(Array.Empty<IMyCubeGrid>());
             ork.ForceSpawn(spawnGroupNames);
+        }
+
+        static void OnGridSet(IMyCubeGrid grid)
+        {
+            // revenge orks have no poi; they fight at the session's current level
+            var level = Session.Instance.GetProgressLevel();
+            OrkHpMultipliers.Register(grid, OrkUtils.ComputeHpMultiplier(level));
         }
 
         void SpawnNoAi(Vector3D center, string[] spawnGroupNames)
@@ -145,6 +153,7 @@ namespace HnzCoopSeason.Orks
                     foreach (var grid in grids)
                     {
                         _noAiGrids.Add(grid);
+                        OnGridSet(grid);
                         var count = OrkUtils.DisarmGrid(grid);
                         MyLog.Default.Info($"[HnzCoopSeason] no-ai ork spawned: '{grid.CustomName}', disarmed blocks: {count}");
 

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/POI/IPoi.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/POI/IPoi.cs
@@ -9,6 +9,10 @@ namespace HnzCoopSeason.POI
         Vector3D Position { get; }
         PoiState State { get; }
         bool IsPlanetary { get; }
+
+        // game-time (GameDateTime.Ticks) the poi last entered Released; 0 if never. persisted.
+        long ReleasedAtGameTicks { get; }
+
         IReadOnlyList<IPoiObserver> Observers { get; }
 
         // get the position of the POI entity, as opposed to the POI origin,

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/POI/Poi.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/POI/Poi.cs
@@ -13,6 +13,7 @@ namespace HnzCoopSeason.POI
         readonly PoiConfig _config;
         readonly IPoiObserver[] _observers;
         readonly string _variableKey;
+        long _releasedAtTicks;
 
         public Poi(PoiConfig config, bool isPlanetary, IPoiObserver[] observers)
         {
@@ -27,6 +28,7 @@ namespace HnzCoopSeason.POI
         public Vector3D Position => _config.Position;
         public bool IsPlanetary { get; }
         public PoiState State { get; private set; }
+        public long ReleasedAtGameTicks => _releasedAtTicks;
         public IReadOnlyList<IPoiObserver> Observers => _observers;
 
         public void Load(IMyCubeGrid[] grids) // called once
@@ -46,6 +48,7 @@ namespace HnzCoopSeason.POI
                 state = PoiState.Occupied;
                 MyLog.Default.Warning($"[HnzCoopSeason] reset poi state to {state}; backward compatibility");
             }
+            _releasedAtTicks = (long)DictionaryExtensions.GetValueOrDefault(builder, nameof(ReleasedAtGameTicks), (long)0);
 
             SetState(state, true);
         }
@@ -72,6 +75,11 @@ namespace HnzCoopSeason.POI
             }
 
             State = state;
+            if (state == PoiState.Released && !init)
+            {
+                _releasedAtTicks = MyAPIGateway.Session.GameDateTime.Ticks;
+            }
+
             foreach (var o in _observers) o.OnStateChanged(State);
 
             if (!init)
@@ -101,6 +109,7 @@ namespace HnzCoopSeason.POI
             var data = new SerializableDictionary<string, object>
             {
                 [nameof(State)] = (int)State,
+                [nameof(ReleasedAtGameTicks)] = _releasedAtTicks,
             };
 
             MyAPIGateway.Utilities.SetVariable(_variableKey, data);

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/ProgressionLevelConfig.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/ProgressionLevelConfig.cs
@@ -12,24 +12,24 @@ namespace HnzCoopSeason
         [XmlAttribute]
         public int MinPlayerCount;
 
-        // effective hp multiplier against ork blocks, lerped from Start to End as progress
+        // damage taken by ork blocks is divided by this, lerped from Start to End as progress
         // crosses this level's span (e.g. level 5 of 5 spans 80%..100%); 1 or less = no reduction
         [XmlAttribute]
-        public float HpMultiplierStart = 1f;
+        public float OrksDamageReductionScaleStart = 1f;
 
         [XmlAttribute]
-        public float HpMultiplierEnd = 1f;
+        public float OrksDamageReductionScaleEnd = 1f;
 
         public ProgressionLevelConfig()
         {
         }
 
-        public ProgressionLevelConfig(int level, int minPlayerCount, float hpStart, float hpEnd)
+        public ProgressionLevelConfig(int level, int minPlayerCount, float scaleStart, float scaleEnd)
         {
             Level = level;
             MinPlayerCount = minPlayerCount;
-            HpMultiplierStart = hpStart;
-            HpMultiplierEnd = hpEnd;
+            OrksDamageReductionScaleStart = scaleStart;
+            OrksDamageReductionScaleEnd = scaleEnd;
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/ProgressionLevelConfig.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/ProgressionLevelConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Xml.Serialization;
 
 namespace HnzCoopSeason
@@ -12,14 +12,24 @@ namespace HnzCoopSeason
         [XmlAttribute]
         public int MinPlayerCount;
 
+        // effective hp multiplier against ork blocks, lerped from Start to End as progress
+        // crosses this level's span (e.g. level 5 of 5 spans 80%..100%); 1 or less = no reduction
+        [XmlAttribute]
+        public float HpMultiplierStart = 1f;
+
+        [XmlAttribute]
+        public float HpMultiplierEnd = 1f;
+
         public ProgressionLevelConfig()
         {
         }
 
-        public ProgressionLevelConfig(int level, int minPlayerCount)
+        public ProgressionLevelConfig(int level, int minPlayerCount, float hpStart, float hpEnd)
         {
             Level = level;
             MinPlayerCount = minPlayerCount;
+            HpMultiplierStart = hpStart;
+            HpMultiplierEnd = hpEnd;
         }
     }
 }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session.cs
@@ -117,7 +117,7 @@ namespace HnzCoopSeason
                 _dataPadInserter?.Unload();
                 PoiRandomInvasion.Instance.Unload();
                 RevengeOrkManager.Instance.Unload();
-                OrkHpMultipliers.Clear();
+                OrkDamageReductionScales.Clear();
                 NpcHud.Instance.Unload();
             }
 

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session.cs
@@ -221,6 +221,15 @@ namespace HnzCoopSeason
             return Math.Min((int)Math.Floor(progress * max) + 1, max);
         }
 
+        // how far progress has crossed the current level's span, 0..1
+        // e.g. level 5 of 5 spans progress 80%..100%; progress 90% -> 0.5
+        public float GetProgressLevelFraction()
+        {
+            var max = SessionConfig.Instance.MaxProgressLevel;
+            var t = GetProgress() * max - (GetProgressLevel() - 1);
+            return MathHelper.Clamp(t, 0f, 1f);
+        }
+
         public bool SetPoiState(string poiId, PoiState state, bool invokeCallbacks = true)
         {
             Poi poi;

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session.cs
@@ -117,6 +117,7 @@ namespace HnzCoopSeason
                 _dataPadInserter?.Unload();
                 PoiRandomInvasion.Instance.Unload();
                 RevengeOrkManager.Instance.Unload();
+                OrkHpMultipliers.Clear();
                 NpcHud.Instance.Unload();
             }
 
@@ -225,8 +226,14 @@ namespace HnzCoopSeason
         // e.g. level 5 of 5 spans progress 80%..100%; progress 90% -> 0.5
         public float GetProgressLevelFraction()
         {
+            return GetProgressLevelFraction(GetProgressLevel());
+        }
+
+        // same, against an arbitrary level's span; a past level clamps to 1, a future one to 0
+        public float GetProgressLevelFraction(int level)
+        {
             var max = SessionConfig.Instance.MaxProgressLevel;
-            var t = GetProgress() * max - (GetProgressLevel() - 1);
+            var t = GetProgress() * max - (level - 1);
             return MathHelper.Clamp(t, 0f, 1f);
         }
 

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
@@ -110,10 +110,10 @@ namespace HnzCoopSeason
         public ProgressionLevelConfig[] ProgressionLevelList =
         {
             new ProgressionLevelConfig(1, 1, 1f, 1f),
-            new ProgressionLevelConfig(2, 1, 1f, 1f),
-            new ProgressionLevelConfig(3, 1, 1f, 1f),
-            new ProgressionLevelConfig(4, 1, 1f, 1f),
-            new ProgressionLevelConfig(5, 1, 1f, 1f)
+            new ProgressionLevelConfig(2, 1, 1f, 1.2f),
+            new ProgressionLevelConfig(3, 1, 1.2f, 1.5f),
+            new ProgressionLevelConfig(4, 1, 1.5f, 2f),
+            new ProgressionLevelConfig(5, 1, 2f, 4f)
         };
 
         public static SessionConfig Instance { get; private set; }

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
@@ -26,6 +26,9 @@ namespace HnzCoopSeason
         public int InvasionIntervalHours = 4;
 
         [XmlElement]
+        public int MaxConcurrentInvasions = 1;
+
+        [XmlElement]
         public int EconomyUpdateIntervalMinutes = 20;
 
         [XmlElement]

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Serialization;
@@ -16,6 +16,8 @@ namespace HnzCoopSeason
     public sealed class SessionConfig
     {
         const string FileName = "HnzCoopSeason.Config.xml";
+
+        static readonly ProgressionLevelConfig FallbackLevel = new ProgressionLevelConfig(); // multipliers default to 1 = no effect
 
         [XmlElement]
         public float EncounterClearance = 500;
@@ -86,9 +88,6 @@ namespace HnzCoopSeason
         [XmlElement]
         public string RespawnDatapadTextFormat = "Come here: {0}";
 
-        [XmlElement]
-        public float OrksDamageManipulationScale = 0.5f;
-
         [XmlArray]
         [XmlArrayItem("Poi")]
         public PoiConfig[] PlanetaryPois = { new PoiConfig() };
@@ -107,17 +106,23 @@ namespace HnzCoopSeason
         [XmlArrayItem("Level")]
         public ProgressionLevelConfig[] ProgressionLevelList =
         {
-            new ProgressionLevelConfig(1, 1),
-            new ProgressionLevelConfig(2, 1),
-            new ProgressionLevelConfig(3, 2),
-            new ProgressionLevelConfig(4, 3),
-            new ProgressionLevelConfig(5, 4)
+            new ProgressionLevelConfig(1, 1, 1f, 1f),
+            new ProgressionLevelConfig(2, 1, 1f, 1f),
+            new ProgressionLevelConfig(3, 1, 1f, 1f),
+            new ProgressionLevelConfig(4, 1, 1f, 1f),
+            new ProgressionLevelConfig(5, 1, 1f, 1f)
         };
 
         public static SessionConfig Instance { get; private set; }
 
         [XmlIgnore]
         public IReadOnlyDictionary<int, ProgressionLevelConfig> ProgressionLevels { get; private set; }
+
+        public ProgressionLevelConfig GetProgressionLevel(int level)
+        {
+            ProgressionLevelConfig c;
+            return ProgressionLevels.TryGetValue(level, out c) ? c : FallbackLevel;
+        }
 
         void Initialize()
         {

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/SessionConfig.cs
@@ -23,7 +23,7 @@ namespace HnzCoopSeason
         public float EncounterClearance = 500;
 
         [XmlElement]
-        public int InvasionIntervalHours = 4;
+        public float InvasionIntervalHours = 4;
 
         [XmlElement]
         public int MaxConcurrentInvasions = 1;

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session_Commands.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session_Commands.cs
@@ -28,11 +28,13 @@ namespace HnzCoopSeason
             _commandModule.Register(new Command("poi release", false, MyPromoteLevel.Moderator, Command_ReleasePoi, "release a POI."));
             _commandModule.Register(new Command("poi occupy", false, MyPromoteLevel.Moderator, Command_OccupyPoi, "invade a POI."));
             _commandModule.Register(new Command("poi invade", false, MyPromoteLevel.Moderator, Command_InvadePoi, "invade a POI."));
+            _commandModule.Register(new Command("poi spawn_noai", false, MyPromoteLevel.Moderator, Command_SpawnNoAi, "spawn ork grids at a POI with remote controls & weapons turned off."));
             _commandModule.Register(new Command("poi spawn", false, MyPromoteLevel.Moderator, Command_Spawn, "spawn grids at a POI given encounter config index."));
             _commandModule.Register(new Command("poi print", false, MyPromoteLevel.Moderator, Command_PrintPoi, "print out the POI state."));
             _commandModule.Register(new Command("stores update", false, MyPromoteLevel.Moderator, Command_UpdateStores, "update all merchant stores."));
             _commandModule.Register(new Command("poi spectate", false, MyPromoteLevel.Moderator, Command_SpectatePoi, "move the spectator camera to a POI."));
             _commandModule.Register(new Command("print", false, MyPromoteLevel.Moderator, Command_Print, "print out the game state."));
+            _commandModule.Register(new Command("revenge spawn_noai", false, MyPromoteLevel.Moderator, Command_RevengeSpawnNoAi, "spawn revenge orks with remote controls & weapons turned off"));
             _commandModule.Register(new Command("revenge spawn", false, MyPromoteLevel.Moderator, Command_RevengeSpawn, "spawn revenge orks"));
             _commandModule.Register(new Command("revenge despawn all", false, MyPromoteLevel.Moderator, Command_RevengeUnloadAll, "despawn all revenge orks"));
             _commandModule.Register(new Command("mission list", false, MyPromoteLevel.Moderator, Command_ListMissions, "list missions"));
@@ -138,6 +140,30 @@ namespace HnzCoopSeason
             }
         }
 
+        void Command_SpawnNoAi(string text, ulong steamId)
+        {
+            var parts = text.Split(' ');
+            var poiId = parts[0];
+            var configIndex = parts[1].ParseIntOrDefault(0);
+
+            Poi poi;
+            if (!_poiMap.TryGetPoi(poiId, out poi))
+            {
+                SendMessage(steamId, Color.Red, $"POI {poiId} not found.");
+                return;
+            }
+
+            if (poi.State != PoiState.Occupied)
+            {
+                SendMessage(steamId, Color.Red, $"POI {poiId} not occupied; orks won't spawn.");
+                return;
+            }
+
+            var ork = poi.Observers.OfType<PoiOrk>().First();
+            ork.Spawn(configIndex, true);
+            SendMessage(steamId, Color.White, $"orks spawning disarmed at {poiId}.");
+        }
+
         void Command_UpdateStores(string text, ulong steamId)
         {
             foreach (var poi in _poiMap.AllPois)
@@ -173,7 +199,17 @@ namespace HnzCoopSeason
             MissionScreen.Send(steamId, "Print", poi.ToString(), true);
         }
 
+        void Command_RevengeSpawnNoAi(string argsStr, ulong steamId)
+        {
+            Command_RevengeSpawn(argsStr, steamId, true);
+        }
+
         void Command_RevengeSpawn(string argsStr, ulong steamId)
+        {
+            Command_RevengeSpawn(argsStr, steamId, false);
+        }
+
+        void Command_RevengeSpawn(string argsStr, ulong steamId, bool disarm)
         {
             MyLog.Default.Info($"[HnzCoopSeason] revenge; args: '{argsStr}'");
             VRageUtils.AssertNetworkType(NetworkType.DediServer | NetworkType.SinglePlayer);
@@ -226,8 +262,8 @@ namespace HnzCoopSeason
             }
 
             var config = configs[configIndex];
-            RevengeOrkManager.Instance.Spawn(targetPosition, config.SpawnGroupNames);
-            SendMessage(steamId, Color.White, $"orks spawned; target: '{targetEntity.DisplayName}', group: {config.SpawnGroupNames.ToStringSeq()}");
+            RevengeOrkManager.Instance.Spawn(targetPosition, config.SpawnGroupNames, disarm);
+            SendMessage(steamId, Color.White, $"orks spawned{(disarm ? " disarmed" : "")}; target: '{targetEntity.DisplayName}', group: {config.SpawnGroupNames.ToStringSeq()}");
         }
 
         void Command_RevengeUnloadAll(string args, ulong steamId)

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session_Commands.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Session_Commands.cs
@@ -34,7 +34,7 @@ namespace HnzCoopSeason
             _commandModule.Register(new Command("stores update", false, MyPromoteLevel.Moderator, Command_UpdateStores, "update all merchant stores."));
             _commandModule.Register(new Command("poi spectate", false, MyPromoteLevel.Moderator, Command_SpectatePoi, "move the spectator camera to a POI."));
             _commandModule.Register(new Command("print", false, MyPromoteLevel.Moderator, Command_Print, "print out the game state."));
-            _commandModule.Register(new Command("revenge spawn_noai", false, MyPromoteLevel.Moderator, Command_RevengeSpawnNoAi, "spawn revenge orks with remote controls & weapons turned off"));
+            _commandModule.Register(new Command("revenge spawn_noai", false, MyPromoteLevel.Moderator, Command_RevengeSpawnNoAi, "spawn revenge orks with remote controls & weapons turned off.\n--level N: override hp-multiplier level (default: ork config's ProgressLevel)."));
             _commandModule.Register(new Command("revenge spawn", false, MyPromoteLevel.Moderator, Command_RevengeSpawn, "spawn revenge orks"));
             _commandModule.Register(new Command("revenge despawn all", false, MyPromoteLevel.Moderator, Command_RevengeUnloadAll, "despawn all revenge orks"));
             _commandModule.Register(new Command("mission list", false, MyPromoteLevel.Moderator, Command_ListMissions, "list missions"));
@@ -214,8 +214,23 @@ namespace HnzCoopSeason
             MyLog.Default.Info($"[HnzCoopSeason] revenge; args: '{argsStr}'");
             VRageUtils.AssertNetworkType(NetworkType.DediServer | NetworkType.SinglePlayer);
 
-            var args = argsStr.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (args.Length < 1)
+            var rawArgs = argsStr.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // --level N: override the hp-multiplier level (default: the ork config's ProgressLevel)
+            var levelOverride = 0;
+            var args = new List<string>();
+            for (var i = 0; i < rawArgs.Length; i++)
+            {
+                if (rawArgs[i] == "--level" && i + 1 < rawArgs.Length && int.TryParse(rawArgs[i + 1], out levelOverride))
+                {
+                    i += 1;
+                    continue;
+                }
+
+                args.Add(rawArgs[i]);
+            }
+
+            if (args.Count < 1)
             {
                 SendMessage(steamId, Color.Red, "requires config index");
                 return;
@@ -230,7 +245,7 @@ namespace HnzCoopSeason
             }
 
             IMyEntity targetEntity;
-            if (args.Length >= 2) // target name specified
+            if (args.Count >= 2) // target name specified
             {
                 var targetName = args[1];
                 if (!TryFindEntityByName(targetName, out targetEntity))
@@ -262,8 +277,9 @@ namespace HnzCoopSeason
             }
 
             var config = configs[configIndex];
-            RevengeOrkManager.Instance.Spawn(targetPosition, config.SpawnGroupNames, disarm);
-            SendMessage(steamId, Color.White, $"orks spawned{(disarm ? " disarmed" : "")}; target: '{targetEntity.DisplayName}', group: {config.SpawnGroupNames.ToStringSeq()}");
+            var level = levelOverride > 0 ? levelOverride : config.ProgressLevel;
+            RevengeOrkManager.Instance.Spawn(targetPosition, config.SpawnGroupNames, level, disarm);
+            SendMessage(steamId, Color.White, $"orks spawned{(disarm ? " disarmed" : "")}; target: '{targetEntity.DisplayName}', level: {level}, group: {config.SpawnGroupNames.ToStringSeq()}");
         }
 
         void Command_RevengeUnloadAll(string args, ulong steamId)

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Spawners/MesEncounter.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Spawners/MesEncounter.cs
@@ -37,6 +37,12 @@ namespace HnzCoopSeason.Spawners
             remove { _mesGridGroup.OnMainGridUnset -= value; }
         }
 
+        public event Action<IMyCubeGrid> OnGridSet
+        {
+            add { _mesGridGroup.OnGridSet += value; }
+            remove { _mesGridGroup.OnGridSet -= value; }
+        }
+
         public FilterSpawnDelegate FilterSpawn { get; set; }
 
         public void Load(IMyCubeGrid[] grids)

--- a/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Spawners/MesGridGroup.cs
+++ b/HnzCoopSeason.Mod/Content/Data/Scripts/HnzCoopSeason/Spawners/MesGridGroup.cs
@@ -34,6 +34,7 @@ namespace HnzCoopSeason.Spawners
 
         public event Action<IMyCubeGrid> OnMainGridSet;
         public event Action<IMyCubeGrid> OnMainGridUnset;
+        public event Action<IMyCubeGrid> OnGridSet; // every grid of the group, main included
 
         public void Load(IEnumerable<IMyCubeGrid> grids) // called once
         {
@@ -60,6 +61,7 @@ namespace HnzCoopSeason.Spawners
 
             MESApi.Instance.RegisterSuccessfulSpawnAction(OnMesAnySuccessfulSpawn, false);
             OnMainGridSet = null;
+            OnGridSet = null;
 
             if (sessionUnload) return; // otherwise fails to unload session
 
@@ -122,6 +124,8 @@ namespace HnzCoopSeason.Spawners
             _allGrids.Add(context.Index, grid);
 
             MESApi.Instance.RegisterDespawnWatcher(grid, OnGridDespawningByMes);
+
+            OnGridSet?.Invoke(grid);
 
             if (context.Index == 0)
             {

--- a/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
+++ b/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
@@ -85,6 +85,7 @@
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\NPC\NpcHud.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\NPC\NpcHudReticle.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Merchants\PoiMerchantStoreConfig.cs" />
+      <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrkHpMultipliers.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrksDamageManipulator.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrkUtils.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiOrk.cs" />

--- a/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
+++ b/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
@@ -86,6 +86,7 @@
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\NPC\NpcHudReticle.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Merchants\PoiMerchantStoreConfig.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrksDamageManipulator.cs" />
+      <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrkUtils.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiOrk.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiOrkConfig.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiRandomInvasion.cs" />

--- a/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
+++ b/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
@@ -85,7 +85,7 @@
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\NPC\NpcHud.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\NPC\NpcHudReticle.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Merchants\PoiMerchantStoreConfig.cs" />
-      <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrkHpMultipliers.cs" />
+      <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrkDamageReductionScales.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrksDamageManipulator.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrkUtils.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiOrk.cs" />

--- a/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
+++ b/HnzCoopSeason.Mod/HnzCoopSeason.Mod.csproj
@@ -84,6 +84,8 @@
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\FlashGps\FlashGpsApi.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\NPC\NpcHud.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\NPC\NpcHudReticle.cs" />
+      <Compile Include="Content\Data\Scripts\HnzCoopSeason\Merchants\PoiMerchantStoreConfig.cs" />
+      <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\OrksDamageManipulator.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiOrk.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiOrkConfig.cs" />
       <Compile Include="Content\Data\Scripts\HnzCoopSeason\Orks\PoiRandomInvasion.cs" />


### PR DESCRIPTION
### 1. New HPMult
- per level mult config
- linear scaler with progress
- HPMult is now independent in each grid based on spawngroup level (previously it was global)

Config example
```xml
<ProgressionLevels>
  <Level Level="1" MinPlayerCount="1" HpMultiplierStart="1" HpMultiplierEnd="1" />
  <Level Level="2" MinPlayerCount="1" HpMultiplierStart="1" HpMultiplierEnd="1.2" />
  <Level Level="3" MinPlayerCount="1" HpMultiplierStart="1.2" HpMultiplierEnd="1.5" />
  <Level Level="4" MinPlayerCount="1" HpMultiplierStart="1.5" HpMultiplierEnd="2" />
  <Level Level="5" MinPlayerCount="1" HpMultiplierStart="2" HpMultiplierEnd="4" />
</ProgressionLevels>
```


### 2. Invade timer rework
- now timer use game elapsed tick instead of tick counting to make timer continue after server restart

### 3. Invade limit uncapped
- now POI can have multiple invasion. previously capped to only 1 POI (3% in meter) can be invade at a time,
it will stop invade if any POI is already invaded. The new one just uncapped the invasion,
so the timer can continue to start invade other POI for more aggressive peace meter reduction.
- stop invade after 100%
```xml
<MaxConcurrentInvasions>4</MaxConcurrentInvasions>
```

### 4. Added `spawn_noai` commands
spawn without MES, weapon & control off for debugging


### ⚠ Config migration required
- `OrksDamageManipulationScale` is removed. Existing configs will silently fall back to new default HpMultiplier of 1.
- `InvasionIntervalHours` int -> float is backward compatible.
- `MaxConcurrentInvasions` is new, defaults to 1.